### PR TITLE
Publish gem

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,22 @@
+name: Publish Gem
+
+on:
+  push:
+    branches:
+      - "*"
+    tags:
+      - v*
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Release Gem
+        if: contains(github.ref, 'refs/tags/v')
+        uses: cadwallion/publish-rubygems-action@master
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          RUBYGEMS_API_KEY: ${{secrets.RUBYGEMS_API_KEY}}
+          RELEASE_COMMAND: rake release

--- a/Rakefile
+++ b/Rakefile
@@ -16,13 +16,6 @@ task :codeclimate do
   sh "./codeclimate.sh", verbose: false
 end
 
-# == "rake release" enhancements ==============================================
-
-Rake::Task["release"].enhance do
-  puts "Don't forget to publish the release on GitHub!"
-  system "open https://github.com/bruce-szalwinski-he/aws-msk-iam-sasl-signer-ruby/releases"
-end
-
 task :disable_overcommit do
   ENV["OVERCOMMIT_DISABLE"] = "1"
 end


### PR DESCRIPTION
publish the gem on release.

- require "bundler/gem_tasks" was already part of the rakefile
- created account on RubyGems, generated API key, added key as secret to the repo
- removed the enhancement to the `release` task that added a reminder to publish the release, as github will publish on release